### PR TITLE
iOS fix for input changing

### DIFF
--- a/src/resources/views/scripts/input-parsing-auto-stepper.blade.php
+++ b/src/resources/views/scripts/input-parsing-auto-stepper.blade.php
@@ -2,7 +2,7 @@
     $(function() {
 
         // Check for on keypress
-        $("input").on("keydown", function(event){
+        $("input").on("keyup", function(event){
 
             var self = $(this);
 


### PR DESCRIPTION
Bug in iOS (potentially other mobile OS but not tested) which meant when you selected the first input and entered the first character, the character is entered into the second input. 

fixes #5 

